### PR TITLE
Add FrameCoach to Misc software

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Find fantastic free creative resources here! This list is perfect for filmmakers
 
 ### 🪀Misc [^](#table)
 - [FontJoy](https://fontjoy.com/) helps you mix and match different fonts to find the perfect font pairing for you.
+- [FrameCoach](https://framecoach.io) is a real-time camera coaching app for filmmakers that guides you through camera settings, composition, and shot choices on set.
 - [Handbrake](https://handbrake.fr/) is an open-source tool for converting video from nearly any format to a selection of modern, widely supported codecs.
 ---
 


### PR DESCRIPTION
## Summary

- Adds [FrameCoach](https://framecoach.io) to the **Misc** section under Software.
- FrameCoach is a real-time camera coaching app for filmmakers that guides you through camera settings, composition, and shot choices on set.

## Why this belongs here

This list is specifically for filmmakers, photographers, and creative professionals. FrameCoach is a free tool designed for on-set filmmaking — it helps with camera settings, composition rules, and shot selection in real time. It's placed in Misc since it doesn't fit neatly into the existing editing, VFX, or graphics categories (it's a production/on-set tool rather than a post-production tool).

## Format

- Follows the existing list style with `[Name](url) description` format
- Placed alphabetically between FontJoy and Handbrake
- Description matches the concise style of other entries