### PR TITLE
Add BulkPicTools to Photo Editing software

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Find fantastic free creative resources here! This list is perfect for filmmakers
 - [RawTherapee](http://rawtherapee.com/) is capable of editing Raw photo files, as well as other formats. With its extensive range of editing tools, you'll be able to correct distortion, boost colors, recover details, and much more.
 - [Darktable](https://www.darktable.org/) is an open-source photography workflow application and raw developer. A virtual light table and darkroom for photographers.
 - [Digikam](https://www.digikam.org/) provides a comprehensive set of tools for importing, managing, editing, and sharing photos and raw files.
+- [BulkPicTools](https://bulkpictools.com) is a free browser-based tool for batch processing images. Compress, resize, crop, convert, and watermark 1,000+ photos at once — all locally in your browser with no account or upload required.
 
 ### 👾 Visual Effects [^](#table)
 - [Natron](https://natrongithub.github.io/) is a free, open-source video compositor, similar in functionality to Adobe After Effects, Foundry's Nuke, or Blackmagic Fusion.


### PR DESCRIPTION
## What

Adding [BulkPicTools](https://bulkpictools.com) to the 📷 Photo Editing section.

## Why it fits

The current Photo Editing section covers great single-image editors (GIMP, Photopea, RawTherapee, etc.), but there's nothing for batch processing — a very common need for photographers and filmmakers who work with large sets of images.

BulkPicTools fills that gap:

- **Batch processing**: Compress, resize, crop, convert, and watermark 1,000+ images in one go
- **Completely free**: No account, no subscription, no limits on number of uses
- **Browser-based & local**: All processing happens on-device — files never leave the computer
- **Format support**: JPG, PNG, WebP, HEIC, AVIF, SVG, and more
- **38+ tools**: Covers the most common image prep tasks photographers and filmmakers need

It meets the freemium criteria — it's fully free with no trial cutoff or usage limits.

## Checklist

- [x] Tool is free / freemium with no use limits (not a trial)
- [x] Not AI-powered (all processing is client-side, no AI substitution of artists)
- [x] Format matches existing entries in the section
- [x] Link is correct: https://bulkpictools.com